### PR TITLE
fix all clang warnings running with  -Wall -Werror -Wextra -Wshadow

### DIFF
--- a/include/nopayloadclient/cli.hpp
+++ b/include/nopayloadclient/cli.hpp
@@ -25,11 +25,11 @@ class CLI {
 typedef json (CLI::*voidFunctionType) ();
 public:
     CLI();
-    virtual json getSize(Client& c, int& argc, char* argv[]);
-    virtual json getConfDict(Client& c, int& argc, char* argv[]);
-    virtual json getPayloadTypes(Client& c, int& argc, char* argv[]);
-    virtual json getGlobalTags(Client& c, int& argc, char* argv[]);
-    virtual json checkConnection(Client& c, int& argc, char* argv[]);
+  virtual json getSize(Client& c, int& /* argc */, char* /* argv[] */);
+    virtual json getConfDict(Client& c, int& /* argv[] */, char* /* argv[] */);
+    virtual json getPayloadTypes(Client& c, int& /* argv[] */, char* /* argv[] */);
+    virtual json getGlobalTags(Client& c, int& /* argv[] */, char* /* argv[] */);
+    virtual json checkConnection(Client& c, int& /* argv[] */, char* /* argv[] */);
     virtual json createPayloadType(Client& c, int& argc, char* argv[]);
     virtual json createGlobalTag(Client& c, int& argc, char* argv[]);
     virtual json deleteGlobalTag(Client& c, int& argc, char* argv[]);

--- a/include/nopayloadclient/curlfaker.hpp
+++ b/include/nopayloadclient/curlfaker.hpp
@@ -22,16 +22,16 @@ public:
     // Reading
     json get(const string& url);
     // Writing
-    json del(const string& url) {
+  json del(const string& /* url */) {
         throw BaseException("no writing implemented in fake backend");
     };
-    json put(const string& url) {
+  json put(const string& /* url */) {
         throw BaseException("no writing implemented in fake backend");
     };
-    json put(const string& url, json jsonData) {
+  json put(const string& /* url */, json /* jsonData */) {
         throw BaseException("no writing implemented in fake backend");
     };
-    json post(const string& url, json jsonData) {
+  json post(const string& /* url */, json /* jsonData */) {
         throw BaseException("no writing implemented in fake backend");
     };
 

--- a/include/nopayloadclient/curlwrapper.hpp
+++ b/include/nopayloadclient/curlwrapper.hpp
@@ -20,6 +20,7 @@ class CurlWrapper {
 public:
     CurlWrapper() {};
     CurlWrapper(const json& config);
+  virtual ~CurlWrapper() = default;
     // Reading
     virtual json get(const string& url);
     // Writing

--- a/include/nopayloadclient/exception.hpp
+++ b/include/nopayloadclient/exception.hpp
@@ -10,6 +10,7 @@ class BaseException : public std::exception {
         std::string pretext_ = "BaseException: ";
         std::string message_;
     public:
+  using std::exception::what;
         BaseException(std::string msg) : message_(msg) {}
         BaseException(int code, std::string pretext, std::string msg) {
             code_ = code;
@@ -35,7 +36,7 @@ class PayloadException : public BaseException {
 
 class DataBaseException : public BaseException {
     private:
-        int http_code_;
+//        int http_code_;
     public:
         DataBaseException(std::string msg) :
             BaseException(3, "DataBaseException: ", msg) {}

--- a/include/nopayloadclient/nopayloadclient.hpp
+++ b/include/nopayloadclient/nopayloadclient.hpp
@@ -10,6 +10,10 @@
 #include <nopayloadclient/config.hpp>
 #include <nopayloadclient/exception.hpp>
 
+#ifdef TRY
+#undef TRY
+#endif
+
 #define TRY(...) {              \
     try {                       \
         __VA_ARGS__             \

--- a/include/rsa/md5.hpp
+++ b/include/rsa/md5.hpp
@@ -156,11 +156,11 @@ documentation and/or software.
 
 // F, G, H and I are basic MD5 functions.
 inline MD5::uint4 MD5::F(uint4 x, uint4 y, uint4 z) {
-  return x&y | ~x&z;
+  return (x&y) | (~x&z);
 }
 
 inline MD5::uint4 MD5::G(uint4 x, uint4 y, uint4 z) {
-  return x&z | y&~z;
+  return (x&z) | (y&~z);
 }
 
 inline MD5::uint4 MD5::H(uint4 x, uint4 y, uint4 z) {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -17,32 +17,32 @@ CLI::CLI() {
     insertCommand("insertPayload", &CLI::insertPayload);
 }
 
-json CLI::getSize(Client& c, int& argc, char* argv[]) {
+json CLI::getSize(Client& c, int& /* argc */, char* /* argv[] */) {
     return c.getSize();
 }
 
-json CLI::createPayloadType(Client& c, int& argc, char* argv[]) {
+  json CLI::createPayloadType(Client& c, int& /* argc */, char* argv[]) {
     std::string name = argv[2];
     return c.createPayloadType(name);
 }
 
-json CLI::getConfDict(Client& c, int& argc, char* argv[]) {
+json CLI::getConfDict(Client& c, int& /* argc */, char* /* argv[] */) {
     return c.getConfDict();
 }
 
-json CLI::getPayloadTypes(Client& c, int& argc, char* argv[]) {
+json CLI::getPayloadTypes(Client& c, int& /* argc */, char* /* argv[] */) {
     return c.getPayloadTypes();
 }
 
-json CLI::getGlobalTags(Client& c, int& argc, char* argv[]) {
+json CLI::getGlobalTags(Client& c, int& /* argc */, char* /* argv[] */) {
     return c.getGlobalTags();
 }
 
-json CLI::checkConnection(Client& c, int& argc, char* argv[]) {
+json CLI::checkConnection(Client& c, int& /* argc */, char* /* argv[] */) {
     return c.checkConnection();
 }
 
-json CLI::getUrlDict(Client& c, int& argc, char* argv[]) {
+json CLI::getUrlDict(Client& c, int& /* argc */, char* argv[]) {
     std::string gt_name = argv[2];
     long long major_iov = std::atoi(argv[3]);
     long long minor_iov = std::atoi(argv[4]);
@@ -50,25 +50,25 @@ json CLI::getUrlDict(Client& c, int& argc, char* argv[]) {
     return c.getUrlDict(major_iov, minor_iov);
 }
 
-json CLI::createGlobalTag(Client& c, int& argc, char* argv[]){
+json CLI::createGlobalTag(Client& c, int& /* argc */, char* argv[]){
     std::string name = argv[2];
     c.setGlobalTag(name);
     return c.createGlobalTag();
 }
 
-json CLI::deleteGlobalTag(Client& c, int& argc, char* argv[]){
+json CLI::deleteGlobalTag(Client& c, int& /* argc */, char* argv[]){
     std::string name = argv[2];
     c.setGlobalTag(name);
     return c.deleteGlobalTag();
 }
 
-json CLI::lockGlobalTag(Client& c, int& argc, char* argv[]){
+json CLI::lockGlobalTag(Client& c, int& /* argc */, char* argv[]){
     std::string name = argv[2];
     c.setGlobalTag(name);
     return c.lockGlobalTag();
 }
 
-json CLI::unlockGlobalTag(Client& c, int& argc, char* argv[]){
+json CLI::unlockGlobalTag(Client& c, int& /* argc */, char* argv[]){
     std::string name = argv[2];
     c.setGlobalTag(name);
     return c.unlockGlobalTag();

--- a/src/payload.cpp
+++ b/src/payload.cpp
@@ -42,12 +42,12 @@ string Payload::getCheckSum() {
 }
 
 string Payload::getRemoteUrl() {
-    string remote_url = remote_dir;
-    remote_url += "/" + check_sum + "_" + bare_file_name;
-    while ( remote_url.find("//") != string::npos ) {
-        remote_url.replace(remote_url.find("//"), 2, "/");
+  string local_remote_url = remote_dir;
+    local_remote_url += "/" + check_sum + "_" + bare_file_name;
+    while ( local_remote_url.find("//") != string::npos ) {
+        local_remote_url.replace(local_remote_url.find("//"), 2, "/");
     }
-    return remote_url;
+    return local_remote_url;
 }
 
 string Payload::getDirsFromChecksum() {
@@ -58,21 +58,21 @@ string Payload::getDirsFromChecksum() {
 }
 
 string Payload::getRemoteDir() {
-    string remote_dir = type;
-    remote_dir += "/" + getDirsFromChecksum();
-    while ( remote_dir.find("//") != string::npos ) {
-        remote_dir.replace(remote_dir.find("//"), 2, "/");
+    string local_remote_dir = type;
+    local_remote_dir += "/" + getDirsFromChecksum();
+    while ( local_remote_dir.find("//") != string::npos ) {
+        local_remote_dir.replace(local_remote_dir.find("//"), 2, "/");
     }
-    return remote_dir;
+    return local_remote_dir;
 }
 
 string Payload::getBareFileName() {
     std::stringstream ss(local_url);
-    string bare_file_name;
+    string local_bare_file_name;
     while (!ss.eof()) {
-        getline(ss, bare_file_name, '/');
+        getline(ss, local_bare_file_name, '/');
     }
-    return bare_file_name;
+    return local_bare_file_name;
 }
 
 std::ostream& operator<<(std::ostream& os, const Payload& pl) {

--- a/src/plhandler.cpp
+++ b/src/plhandler.cpp
@@ -17,19 +17,19 @@ bool PLHandler::fileExists(const string& url) {
 }
 
 string PLHandler::getFirstGoodUrl(Payload& pl) {
-     for (const auto dir : read_dir_list_) {
+     for (const auto &dir : read_dir_list_) {
          string full_url = dir + pl.remote_url;
          if (fileExists(full_url)) return full_url;
      }
      string text = "Could not find payload <" + pl.remote_url + "> ";
      text += "in any of the following read dirs:";
-     for (const auto dir : read_dir_list_) {
+     for (const auto &dir : read_dir_list_) {
          text += " " + dir;
      }
      throw BaseException(text);
 }
 
-void PLHandler::compareCheckSums(const string& firstFileUrl, const string& secondFileUrl){
+  void PLHandler::compareCheckSums(const string& /* firstFileUrl */, const string& /* secondFileUrl */){
     /*
     string firstCheckSum = getCheckSum(firstFileUrl);
     string secondCheckSum = getCheckSum(secondFileUrl);


### PR DESCRIPTION
I got tons of warnings when compiling sphenixnpc with clang using picky warnings flags. They can be dealt with on our end by just disabling those warnings but this is probably better handled upstream. Mostly it is "cosmetic" but there were some more serious ones about shadowed variables which tend to bite one when modifying code since one doesn't see which variable one actually changes.
One problem which isn't addressed here is the use of the insertPayload   method with varying arguments as public and private method. There is no way to deal with this in a derived class like sphenixnpc without getting a -Woverloaded-virtual. Typically one can use
using nopayloadclient::Client::insertPayload;
to tell the compiler one knows that there are virtual methods which are not overridden but this bombs because the compiler interprets this as also using a private method.
I started to look into sphenixnpc. The class itself (except the above insertPayload clash) is easy but the cli turns out to be pages of warnings. gcc seems to be fine but clang just refuses to compile this.