### PR TITLE
remove virtual from private getUrlDict method

### DIFF
--- a/include/nopayloadclient/nopayloadclient.hpp
+++ b/include/nopayloadclient/nopayloadclient.hpp
@@ -95,7 +95,7 @@ private:
     virtual void checkGtStatusExists(const string& name);
     virtual void checkPlTypeExists(const string& name);
     //virtual json getUrlDict(const std::vector<PayloadIOV>& payload_iovs);
-    virtual json getUrlDict(const json& payload_iovs);
+    json getUrlDict(const json& payload_iovs);
 
     // Helper
     virtual bool objWithNameExists(const json& j, const string& name);


### PR DESCRIPTION
There seems to be no way to compile a derived class which overrides a public virtual method and installing its own with different arguments when the parent class has a virtual private method using the same name as public method with clang 14. The usual trick 
using nopayloadclient::Client::getUrlDict;
stumbles over the private method. I don't think virtual private methods are needed since they cannot be overridden by a daughter class anyway