### PR TITLE
change retry mechanics

### DIFF
--- a/src/realwrapper.cpp
+++ b/src/realwrapper.cpp
@@ -1,5 +1,7 @@
 #include <nopayloadclient/realwrapper.hpp>
 
+#include <cstdlib>
+
 namespace nopayloadclient {
 
 RealWrapper::RealWrapper(const json& config) {
@@ -10,7 +12,8 @@ RealWrapper::RealWrapper(const json& config) {
 }
 
 void RealWrapper::sleep(int retry_number) {
-    int n_sleep = int(std::exp(retry_number));
+    srand(time(0));
+    int n_sleep = rand()%100+1; // add random sleep 1-100 secs
     logging::debug("sleeping for " + std::to_string(n_sleep) + " seconds before retrying...");
     std::this_thread::sleep_for(std::chrono::seconds(n_sleep));
 }


### PR DESCRIPTION
This PR is just a proposal to change the retry timing. The previous hardcoded exp(n_retry) leads to continuing timeouts if many jobs start simultaneously (up to 60k in my case, >100k end of 2024). The DB can handle a few hundred requests at most, so almost all jobs have to retry. Using a fixed time interval just have all remaining jobs pounce on the DB at the same time and most of them will have to retry again. Adding retries does not help but the exp leads to hourlong intervals where the compute node is just wasted (>9) very quickly.
What is needed is some randomized interval to break this cycle. It's not clear to me that some ever increasing interval is actually useful (where exp() just increases too rapidly). Typically this situation happens when jobs are submitted to an empty farm. If the DB can handle 100 connections with a sub second response time, 60k jobs can be handled in 600seconds (instead of , so setting the random interval to 1-100 seconds for each retry should get everything going after 6 retries but likely this needs to be played with. Maybe a config parameter for this should be added. Maybe a combination of increasing intervals and some randomization on top of that is more suitable for other scenarios but for starting up quickly increasing the interval will just delay the startup  