### PR TITLE
Check dir create

### DIFF
--- a/src/nopayloadclient.cpp
+++ b/src/nopayloadclient.cpp
@@ -266,8 +266,8 @@ json NoPayloadClient::makeResp(T msg) {
 void NoPayloadClient::insertPayload(Payload &pl, IOV &iov) {
     prepareInsertIov(pl);
     pl_handler_.prepareUploadFile(pl);
-    insertIov(pl, iov);
     pl_handler_.uploadFile(pl);
+    insertIov(pl, iov);
 }
 
 void NoPayloadClient::prepareInsertIov(Payload &pl) {

--- a/src/plhandler.cpp
+++ b/src/plhandler.cpp
@@ -73,7 +73,12 @@ void PLHandler::checkRemoteDirExists() {
 
 void PLHandler::createDirectory(const string& path){
     if (!fs::is_directory(path) || !fs::exists(path)) {
-        fs::create_directories(path);
+      try{
+          fs::create_directories(path);
+      }
+      catch(...){
+        throw BaseException("remote payload directory "+path+" could not be created");
+      }
     }
 }
 
@@ -85,7 +90,10 @@ void PLHandler::prepareUploadFile(const Payload& pl) {
 
 void PLHandler::copyFile(const string& local_url, const string& remote_url) {
     if (!fs::exists(remote_url)) {
-        fs::copy_file(local_url, remote_url);
+      if (! fs::copy_file(local_url, remote_url))
+      {
+        throw BaseException("could not copy "+local_url+" to "+remote_url);
+      }
     }
 }
 

--- a/src/realwrapper.cpp
+++ b/src/realwrapper.cpp
@@ -1,5 +1,7 @@
 #include <nopayloadclient/realwrapper.hpp>
 
+#include <cstdlib>
+
 namespace nopayloadclient {
 
 RealWrapper::RealWrapper(const json& config) {
@@ -10,7 +12,8 @@ RealWrapper::RealWrapper(const json& config) {
 }
 
 void RealWrapper::sleep(int retry_number) {
-    int n_sleep = int(std::exp(retry_number));
+    srand(time(0));
+    int n_sleep = rand()%100+1; // add random sleep 1-100 secs
     logging::debug("sleeping for " + std::to_string(n_sleep) + " seconds before retrying...");
     std::this_thread::sleep_for(std::chrono::seconds(n_sleep));
 }


### PR DESCRIPTION
This PR fixes a problem we had where users inserted payloads where the creation of the path for the file failed since the user did not have write permission. The resulting entry in the cdb brought everything to a screeching halt since it checks if all calibrations exist. This result then in misleading error messages where you load a given calibration but the error mentions a completely different one. E.g. with our interface, trying to read the Centrality calibration:
getCalibration("Centrality",120000)
results in
BaseException: Could not find payload <cemc_PDC_ResidualCorr/41/ab/41ab0d98bff8206763951a48d3461252_pdc_res_e_eta.root> in any of the following read dirs: /cvmfs/sphenix.sdcc.bnl.gov/calibrations/sphnxpro/cdb/ /sphenix/cvmfscalib/sphnxpro/cdb/"
which made us look into parsing problems to see how Centrality changes to cemc_PDC_ResidualCorr

Now it will throw a BaseException if the creation of the directory or the file copying fails. This PR sits on top of the recent ntry PR since both affect the nopayloadclient.cpp 
