### PR TITLE
Compile with optimization

### DIFF
--- a/src/nopayloadclient.cpp
+++ b/src/nopayloadclient.cpp
@@ -262,6 +262,8 @@ json NoPayloadClient::makeResp(T msg) {
     return {{"code", 0}, {"msg", msg}};
 }
 
+template json NoPayloadClient::makeResp(json);
+
 // Private
 void NoPayloadClient::insertPayload(Payload &pl, IOV &iov) {
     prepareInsertIov(pl);

--- a/src/nopayloadclient.cpp
+++ b/src/nopayloadclient.cpp
@@ -266,8 +266,8 @@ json NoPayloadClient::makeResp(T msg) {
 void NoPayloadClient::insertPayload(Payload &pl, IOV &iov) {
     prepareInsertIov(pl);
     pl_handler_.prepareUploadFile(pl);
-    insertIov(pl, iov);
     pl_handler_.uploadFile(pl);
+    insertIov(pl, iov);
 }
 
 void NoPayloadClient::prepareInsertIov(Payload &pl) {

--- a/src/plhandler.cpp
+++ b/src/plhandler.cpp
@@ -73,7 +73,12 @@ void PLHandler::checkRemoteDirExists() {
 
 void PLHandler::createDirectory(const string& path){
     if (!fs::is_directory(path) || !fs::exists(path)) {
-        fs::create_directories(path);
+      try{
+          fs::create_directories(path);
+      }
+      catch(...){
+        throw BaseException("remote payload directory "+path+" could not be created");
+      }
     }
 }
 
@@ -85,7 +90,10 @@ void PLHandler::prepareUploadFile(const Payload& pl) {
 
 void PLHandler::copyFile(const string& local_url, const string& remote_url) {
     if (!fs::exists(remote_url)) {
-        fs::copy_file(local_url, remote_url);
+      if (! fs::copy_file(local_url, remote_url))
+      {
+        throw BaseException("could not copy "+local_url+" to "+remote_url);
+      }
     }
 }
 

--- a/src/realwrapper.cpp
+++ b/src/realwrapper.cpp
@@ -1,5 +1,7 @@
 #include <nopayloadclient/realwrapper.hpp>
 
+#include <cstdlib>
+
 namespace nopayloadclient {
 
 RealWrapper::RealWrapper(const json& config) {
@@ -10,7 +12,8 @@ RealWrapper::RealWrapper(const json& config) {
 }
 
 void RealWrapper::sleep(int retry_number) {
-    int n_sleep = int(std::exp(retry_number));
+    srand(time(0));
+    int n_sleep = rand()%100+1; // add random sleep 1-100 secs
     logging::debug("sleeping for " + std::to_string(n_sleep) + " seconds before retrying...");
     std::this_thread::sleep_for(std::chrono::seconds(n_sleep));
 }


### PR DESCRIPTION
I finally tracked down the reason for the unresolved symbol which has been bugging me for a year. Whenever compiling with -O2 it showed up:
root.exe: symbol lookup error: /direct/phenix+u/pinkenbu/workarea/sPHENIX/gitrepov5/install/lib/libsphenixnpc.so.0.0.0: undefined symbol: _ZN15nopayloadclient15NoPayloadClient8makeRespIN8nlohmann10basic_jsonISt3mapSt6vectorNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEblmdSaNS2_14adl_serializerES5_IhSaIhEEEEEESF_T_
[pinkenbu@sphnxdev01 CDBTest]$ c++filt _ZN15nopayloadclient15NoPayloadClient8makeRespIN8nlohmann10basic_jsonISt3mapSt6vectorNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEblmdSaNS2_14adl_serializerES5_IhSaIhEEEEEESF_T_
nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > nopayloadclient::NoPayloadClient::makeResp<nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > >(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > >)

Googling pointed to similar problems, it was this template declaration:

template<typename T>
json NoPayloadClient::makeResp(T msg) {
    return {{"code", 0}, {"msg", msg}};
}

it needs to be explicitly instantiated in the .cpp file so the optimizer doesn't get rid of it. Just adding a single line:

template json NoPayloadClient::makeResp(json);

fixes this.
